### PR TITLE
Fix parsing references to structs in same package

### DIFF
--- a/struct_comment.go
+++ b/struct_comment.go
@@ -21,6 +21,10 @@ func GetDescribeFromComment(doc *ast.CommentGroup, comment *ast.CommentGroup) st
 	if comment != nil {
 		res += TrimComment(comment.Text())
 	}
+	// skip comments starting with plus sign, as used by kubebuilder
+	if strings.HasPrefix(res, "+") {
+		res = ""
+	}
 
 	return res
 }

--- a/struct_comment.go
+++ b/struct_comment.go
@@ -21,7 +21,7 @@ func GetDescribeFromComment(doc *ast.CommentGroup, comment *ast.CommentGroup) st
 	if comment != nil {
 		res += TrimComment(comment.Text())
 	}
-	// skip comments starting with plus sign, as used by kubebuilder
+	// skip comments starting with plus sign, known as "markers" and used for example by kubebuilder
 	if strings.HasPrefix(res, "+") {
 		res = ""
 	}

--- a/struct_parser.go
+++ b/struct_parser.go
@@ -103,11 +103,8 @@ func (p *Parser) parseFileStruct(
 	structInfo := p.parseStruct(objStructType, typeDocMap[objName])
 	res[typeKey] = structInfo
 	for idx, field := range structInfo.Fields {
-		if field.Reference == "" {
-			continue
-		}
 		subModPath := ""
-		if field.Reference == "." {
+		if field.Reference == "" || field.Reference == "." {
 			subModPath = modPath
 		} else {
 			subModPath = namedImportMap[field.Reference]

--- a/test/ext/post.go
+++ b/test/ext/post.go
@@ -1,0 +1,17 @@
+package ext
+
+// Post hook config.
+type Post struct {
+	Name     string            `json:"name" require:"" default:"example"` // hook name
+	Commands []string          `json:"commands"`                          // command list
+	Envs     map[string]string `json:"envs"`                              // env key map
+	Mode     Mode              `json:"mode" default:"1"`                  // run mode
+}
+
+// Mode mode define.
+type Mode int
+
+const (
+	Mode_Q Mode = iota + 1 // mode q
+	Mode_A                 // mode a
+)

--- a/test/post.go
+++ b/test/post.go
@@ -1,17 +1,11 @@
-package ext
+package test
 
-// Hook hook config.
-type Hook struct {
+import "github.com/eleztian/type2md/test/ext"
+
+// Pre hook config.
+type Pre struct {
 	Name     string            `json:"name" require:"" default:"example"` // hook name
 	Commands []string          `json:"commands"`                          // command list
 	Envs     map[string]string `json:"envs"`                              // env key map
-	Mode     Mode              `json:"mode" default:"1"`                  // run mode
+	Mode     ext.Mode          `json:"mode" default:"1"`                  // run mode
 }
-
-// Mode mode define.
-type Mode int
-
-const (
-	Mode_Q Mode = iota + 1 // mode q
-	Mode_A                 // mode a
-)

--- a/test/test.go
+++ b/test/test.go
@@ -6,8 +6,8 @@ import "github.com/eleztian/type2md/test/ext"
 
 // Config doc.
 type Config struct {
-	Pre     ext.Hook
-	Post    *ext.Hook
+	Pre     Pre
+	Post    *ext.Post
 	Servers map[string]struct {
 		Host string `json:"host,omitempty"`
 		Port int    `json:"port" enums:"22,65522" require:"false"`
@@ -27,8 +27,8 @@ type InlineStruct struct {
 // OtherStruct other struct
 // this is use for test.
 type OtherStruct struct {
-	A string                 `json:"a" require:"true" default:"default value"`
-	B [][2]ext.Mode          `json:"b"` // array string
-	C map[string]interface{} `json:"c"` // map[string]interface{}
-	D *OtherStruct           `json:"d"` // nested struct
+	A string                 `json:"a" require:"true" default:"default value"` // +optional
+	B [][2]ext.Mode          `json:"b"`                                        // array string
+	C map[string]interface{} `json:"c"`                                        // map[string]interface{}
+	D *OtherStruct           `json:"d"`                                        // nested struct
 }


### PR DESCRIPTION
Currently `ext.Hook` is correctly parsed but if you move `Hook` out of the `ext` package it's ignored. This PR fixes that. See the updated test case: both `Pre` and `Post` are rendered in the Markdown output. 

Note: this change does introduce one side effect: types like string, int, etc are also turned into links.

Also added small change to skip comments starting with a `+` since these are "markers". See for example https://book.kubebuilder.io/reference/markers/crd or https://github.com/codnect/markers